### PR TITLE
Feat verbnet link copy

### DIFF
--- a/uvi_web/static/js/utility.js
+++ b/uvi_web/static/js/utility.js
@@ -1,0 +1,34 @@
+/*
+  Common utility file for entire uvi project
+  Format of writing:
+    * Add the name of file or feature (in case of multiple files) the function is being used in
+    * Mention the reference (Ref) if the code is being reused for an external source
+*/
+
+/**
+ * 
+ * @param {object} ctx 
+ * @param {string} className 
+ * 
+ * Function to copy path of the verbnet class/subclass.
+ * Usage in: files with name render_verbnet(_*).html
+ */
+function copyToClipboard(ctx, className) {
+    var classPath = new URL(window.location.origin + className);
+    // Ref: https://techoverflow.net/2018/03/30/copying-strings-to-the-clipboard-using-pure-javascript/
+    var el = document.createElement('textarea');
+    // Set value (string to be copied)
+    el.value = classPath.href;
+    // Set non-editable to avoid focus and move outside of view
+    el.setAttribute('readonly', '');
+    el.style = {position: 'absolute', left: '-9999px'};
+    document.body.appendChild(el);
+    // Select text inside element
+    el.select();
+    // Copy text to clipboard
+    var successful = document.execCommand('copy');
+    var msg = successful ? 'Copied!' : 'Whoops, not copied!';
+    $(ctx).find('i').attr('data-original-title', msg).tooltip('show');
+    // Remove temporary element
+    document.body.removeChild(el);
+}

--- a/uvi_web/static/js/utility.js
+++ b/uvi_web/static/js/utility.js
@@ -7,10 +7,11 @@
 
 /**
  * 
- * @param {object} ctx 
- * @param {string} className 
+ * @param {object} ctx icon element that has been clicked
+ * @param {string} className verbnet class whose link need to be stored; can be a sub-class as well
  * 
- * Function to copy path of the verbnet class/subclass.
+ * Function to copy path of the verbnet class/sub-class.
+ * Extends the redirection ability of "Class Hierarchy" which is limited to class only (and not sub-classes)
  * Usage in: files with name render_verbnet(_*).html
  */
 function copyToClipboard(ctx, className) {
@@ -29,6 +30,8 @@ function copyToClipboard(ctx, className) {
     var successful = document.execCommand('copy');
     var msg = successful ? 'Copied!' : 'Whoops, not copied!';
     $(ctx).find('i').attr('data-original-title', msg).tooltip('show');
+    // Reset the tooltip content but no need to show
+    $(ctx).find('i').attr('data-original-title', 'Click to copy link');
     // Remove temporary element
     document.body.removeChild(el);
 }

--- a/uvi_web/templates/bootstrap_base_iframe.html
+++ b/uvi_web/templates/bootstrap_base_iframe.html
@@ -11,6 +11,7 @@
         <!-- <link rel='stylesheet' href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.1.2/materia/bootstrap.min.css" crossorigin='anonymous'> -->
         <link rel="stylesheet" href="/static/css/bootstrap_materia.css">
         <link rel="stylesheet" href="/static/css/bootstrap_custom.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="icon" type="image/png" href="/static/images/clear_orig.png"/>
 
 
@@ -23,7 +24,7 @@
           crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js" integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T" crossorigin="anonymous"></script>
-
+        <script src="/static/js/utility.js"></script>
         {% endblock %}
 
         <title>{% block title %}{% endblock %}</title>

--- a/uvi_web/templates/class_hierarchy.html
+++ b/uvi_web/templates/class_hierarchy.html
@@ -2,9 +2,7 @@
 {% block title %} Class Hierarchy {% endblock %}
 {% block body %}
 
-
 {% include 'navbar.html' %}
-
 
 <div id='home_span' style="margin-top:190px;">
   <br>
@@ -29,7 +27,6 @@
             {% endfor %}
           </section>
           {% endfor %}
-          
         </article>
       </div>
       <div role="tabpanel" class="tab-pane" id="tab_name">
@@ -52,7 +49,6 @@
             {% endfor %}
           </section>
           {% endfor %}
-          
         </article>
     </div>
   </div>
@@ -62,101 +58,90 @@
 
 <style type="text/css">
 
-#ButtonsPage {
-  background: rgba(122, 157, 150, .9);
-  margin:auto;
-}
+  #ButtonsPage {
+    background: rgba(122, 157, 150, .9);
+    margin:auto;
+  }
 
-#hierPage{
-  background: rgba(122, 157, 150, .9);
-  overflow-y:auto;
-  overflow-x: hidden;
-  margin: auto;
-  height:72vh;
-  
+  #hierPage{
+    background: rgba(122, 157, 150, .9);
+    overflow-y:auto;
+    overflow-x: hidden;
+    margin: auto;
+    height:72vh;
+  }
 
-}
+  .button {
+    background-color: rgba(220, 174, 29, .9); /* Green */
+    border: none;
+    padding: 15px 32px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 14px;
+    margin: 10px;
+    color: black;
+    text-transform: uppercase;
+  }
 
-.button {
-  background-color: rgba(220, 174, 29, .9); /* Green */
-  border: none;
-  padding: 15px 32px;
-  text-align: center;
-  text-decoration: none;
+  a:hover {
+    color: #202a0a; /*Shade of olive*/
+  }
+
+  .no-underline{
+    text-decoration: none;
+  }
+
+
+  #bothButtons {
+    justify-content: center;
+  }
+
+  .wordStyle {
+    text-decoration: none; 
+    color: black;
+    /*font-weight: bold;*/
+    font-size: 16px;
+    /*margin-left: 6px;*/
+  }
+
+  /* https://speckyboy.com/snippets-masonry-grid-layouts/ - for the masonry layout*/
+  @import "compass/css3";
+  *, *:before, *:after {
+    box-sizing:  border-box !important;
+  }
+
+  article {
+  -moz-column-width: 20em;
+  -webkit-column-width: 20em;
+  -moz-column-gap: 1em;
+  -webkit-column-gap: 1em; 
+  width: 100%;
+  }
+
+  section {
   display: inline-block;
-  font-size: 14px;
-  margin: 10px;
-  color: black;
-  text-transform: uppercase;
-}
+  margin:  0.25rem;
+  padding:  1rem;
+  width:  100%; 
+  background:  rgba(255, 255, 210, 0.9); /* Very pale yellow color*/
+  float: left;
+  border-radius: 8px;
+  }
 
-a:hover {
-  color: ##202a0a; /*Shade of olive*/
-}
+  p {
+  margin:  1rem 0; 
+  }
 
-.no-underline{
-  text-decoration: none;
-}
-
-
-#bothButtons {
-  justify-content: center;
-}
-
-.wordStyle {
-  text-decoration: none; 
-  color: black;
-  /*font-weight: bold;*/
-  font-size: 16px;
-  /*margin-left: 6px;*/
-}
-
-/* https://speckyboy.com/snippets-masonry-grid-layouts/ - for the masonry layout*/
-@import "compass/css3";
-
-*, *:before, *:after {box-sizing:  border-box !important;}
-
-
-article {
- -moz-column-width: 20em;
- -webkit-column-width: 20em;
- -moz-column-gap: 1em;
- -webkit-column-gap: 1em; 
- width: 100%;
-
-}
-
-section {
- display: inline-block;
- margin:  0.25rem;
- padding:  1rem;
- width:  100%; 
- background:  rgba(255, 255, 210, 0.9); /* Very pale yellow color*/
- float: left;
- border-radius: 8px;
-}
-
-
-p {
- margin:  1rem 0; 
-}
-
-
-
-
-/*  styles for background color, etc; not necessary for this thing to work  */
-
-
-p {
- text-align:  left;
-}
+  /*  styles for background color, etc; not necessary for this thing to work  */
+  p {
+  text-align:  left;
+  }
 
 </style>
-
 
 {% endblock %}
 
 {% block scripts %}
-
 
 {% endblock %}

--- a/uvi_web/templates/render_verbnet.html
+++ b/uvi_web/templates/render_verbnet.html
@@ -13,6 +13,12 @@
           {% endif %}
           <h5>{{ vn_class_json['class_id'] }}</h5>
           </button>
+          {% set verb_class = url_for('render_vn_class', vn_class_id=vn_class_json['class_id']) %}
+          <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
+            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+              tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
+            </i>
+          </span>
         </h5>
       </div>
       <div id="collapse_{{id}}" class="collapse" data-parent="#{{accordion_id}}">
@@ -193,3 +199,10 @@
     {% endfor %}
   </div>
 </body>
+<script>
+  $(document).ready(function(){
+    $('[tool-tip-toggle="tooltip-clipboard"]').tooltip({
+      placement : 'bottom'
+    });
+  });
+</script>

--- a/uvi_web/templates/render_verbnet.html
+++ b/uvi_web/templates/render_verbnet.html
@@ -15,7 +15,7 @@
           </button>
           {% set verb_class = url_for('render_vn_class', vn_class_id=vn_class_json['class_id']) %}
           <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
-            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+            <i class="fa fa-clipboard" style="font-size: 20px"
               tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
             </i>
           </span>

--- a/uvi_web/templates/render_verbnet_parent.html
+++ b/uvi_web/templates/render_verbnet_parent.html
@@ -16,7 +16,7 @@
           </button>
           {% set verb_class = url_for('render_vn_class', vn_class_id=vn_parent_json['class_id']) %}
           <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
-            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+            <i class="fa fa-clipboard" style="font-size: 20px"
               tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
             </i>
           </span>

--- a/uvi_web/templates/render_verbnet_parent.html
+++ b/uvi_web/templates/render_verbnet_parent.html
@@ -14,6 +14,12 @@
           {% endif %}
           <h5>{{ vn_parent_json['class_id'] }}</h5>
           </button>
+          {% set verb_class = url_for('render_vn_class', vn_class_id=vn_parent_json['class_id']) %}
+          <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
+            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+              tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
+            </i>
+          </span>
         </h5>
       </div>
 
@@ -100,3 +106,10 @@
     {% endfor %}
   </div>
 </body>
+<script>
+  $(document).ready(function(){
+    $('[tool-tip-toggle="tooltip-clipboard"]').tooltip({
+      placement : 'bottom'
+    });
+  });
+</script>

--- a/uvi_web/templates/render_verbnet_top.html
+++ b/uvi_web/templates/render_verbnet_top.html
@@ -20,6 +20,11 @@ to function improperly), making a separate top-level template necessary. Any rec
           {% endif %}
           <h5>{{ vn_class_json['class_id'] }}</h5>
           </button>
+          {% set verb_class = url_for('render_vn_class', vn_class_id=vn_class_json['class_id']) %}
+          <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
+            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+              tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
+            </i>
         </h5>
       </div>
       <div id="collapse_{{id}}" class="collapse show" data-parent="#{{accordion_id}}">
@@ -201,4 +206,11 @@ to function improperly), making a separate top-level template necessary. Any rec
     {% endfor %}
   </div>
 </body>
+<script>
+  $(document).ready(function(){
+    $('[tool-tip-toggle="tooltip-clipboard"]').tooltip({
+      placement : 'bottom'
+    });
+  });
+</script>
 {% endblock %}

--- a/uvi_web/templates/render_verbnet_top.html
+++ b/uvi_web/templates/render_verbnet_top.html
@@ -22,7 +22,7 @@ to function improperly), making a separate top-level template necessary. Any rec
           </button>
           {% set verb_class = url_for('render_vn_class', vn_class_id=vn_class_json['class_id']) %}
           <span style="cursor: pointer" onclick="copyToClipboard(this, '{{ verb_class }}')">
-            <i class="fa fa-clipboard fa-2x" style="vertical-align: middle" 
+            <i class="fa fa-clipboard" style="font-size: 20px"
               tool-tip-toggle="tooltip-clipboard" data-original-title="Click to copy link">
             </i>
         </h5>


### PR DESCRIPTION
Changes:
- A new icon beside class/sub-class name in verbnet
- Clicking the icon will be make the link to the classname available for sharing
- A separate js file (static/js/utility.js) has been created to keep all js-driven functionalities at single place