### PR TITLE
"Reference Page" navbar style correction

### DIFF
--- a/uvi_web/templates/references.html
+++ b/uvi_web/templates/references.html
@@ -247,7 +247,7 @@
 <style type="text/css">
 #optionsBox, #pageInfo {
     border-radius: 25px;
-    height:90%;
+    height:75%;
     margin:10px;
     padding:20px;
 }
@@ -260,7 +260,6 @@
     overflow-y:auto;
 }
 #wrapper {
-    height: 100%;
     margin-left: 20px;
     margin-top: 20px;
 }


### PR DESCRIPTION
- Reverted earlier change of 90% height back to 75%.
- Removed wrapper height so that the it is inherited from the parent.